### PR TITLE
Fix recording settings not being saved

### DIFF
--- a/app/views/cameras/single/_snapshots_navigator_tab.html.erb
+++ b/app/views/cameras/single/_snapshots_navigator_tab.html.erb
@@ -178,12 +178,13 @@
           </div>
         </div>
         <div id="cloud-recording-duration-wrap" class="hide">
-          <b>Snapshots per minute:</b>
+          <b>Storage duration:</b>
           <select id="cloud-recording-duration" style="width: 175px;">
             <option value="1">24 hours recording</option>
             <option value="7">7 days recording</option>
             <option value="30">30 days recording</option>
             <option value="90">90 days recording</option>
+            <option value="-1">Indefinite</option>
           </select>
         </div>
         <div id="cloud-recording-frequency-wrap" class="hide">


### PR DESCRIPTION
Added an option for "indefinite" storage duration, to support existing
cameras which don't have a set deletion date for snapshots.