### PR TITLE
Removed functionality to add `dash` on space in preset name

### DIFF
--- a/app/assets/javascripts/cameras/single/live_view.js.coffee
+++ b/app/assets/javascripts/cameras/single/live_view.js.coffee
@@ -430,6 +430,7 @@ createPtzPresets = (preset_name) ->
     success: onSuccess
     error: onError
     type: 'POST'
+    contentType: 'application/x-www-form-urlencoded'
     url: "#{Evercam.API_URL}cameras/#{Evercam.Camera.id}/ptz/presets/create?api_id=#{Evercam.User.api_id}&api_key=#{Evercam.User.api_key}"
   sendAJAXRequest(settings)
 

--- a/app/assets/javascripts/cameras/single/live_view.js.coffee
+++ b/app/assets/javascripts/cameras/single/live_view.js.coffee
@@ -411,10 +411,8 @@ ptzCreation = ->
 
 createPtzPresets = (preset_name) ->
   NProgress.start()
-  preset = preset_name.toLowerCase()
-  preset = preset_name.replace(/(^\s+|[^a-zA-Z0-9 ]+|\s+$)/g, '')
-  preset = preset_name.replace(/\s+/g, '-')
   data = {}
+  data.preset_name = preset_name
 
   onError = (jqXHR, status, error) ->
     message = jqXHR.responseJSON.message
@@ -431,9 +429,8 @@ createPtzPresets = (preset_name) ->
     dataType: 'json'
     success: onSuccess
     error: onError
-    contentType: "application/json; charset=utf-8"
     type: 'POST'
-    url: "#{Evercam.API_URL}cameras/#{Evercam.Camera.id}/ptz/presets/create/#{preset}?api_id=#{Evercam.User.api_id}&api_key=#{Evercam.User.api_key}"
+    url: "#{Evercam.API_URL}cameras/#{Evercam.Camera.id}/ptz/presets/create?api_id=#{Evercam.User.api_id}&api_key=#{Evercam.User.api_key}"
   sendAJAXRequest(settings)
 
 refreshPresetList = ->


### PR DESCRIPTION
Also changed the route for creating presets..

Removed `contentType: "application/json; charset=utf-8"` as it was converting spaces to special chars and on evercam media side `Poison` was unable to decode the `json`

/cc @azharmalik3 